### PR TITLE
Fix blocking thread issue on the Webflux variant

### DIFF
--- a/spring-boot-webflux/src/main/java/com/cogrammer/controller/ExampleController.java
+++ b/spring-boot-webflux/src/main/java/com/cogrammer/controller/ExampleController.java
@@ -19,7 +19,7 @@ public class ExampleController {
 
     @GetMapping(path = "/hello")
     public Mono<Message> hello() {
-        return service.blockingHello();
+        return service.delayedHello();
     }
 
     @GetMapping(path = "/cities")

--- a/spring-boot-webflux/src/main/java/com/cogrammer/service/ExampleService.java
+++ b/spring-boot-webflux/src/main/java/com/cogrammer/service/ExampleService.java
@@ -1,34 +1,31 @@
 package com.cogrammer.service;
 
+import java.time.Duration;
+
 import com.cogrammer.dto.Cities;
 import com.cogrammer.dto.City;
 import com.cogrammer.dto.Message;
 import com.cogrammer.repository.CityRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class ExampleService {
 
-    private final CityRepository repository;
+	private final CityRepository repository;
 
-    public Mono<Message> blockingHello() {
-        return Mono.fromSupplier(() -> {
-            try {
-                Thread.sleep(100);
-                return new Message("Hello!");
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        });
-    }
+	public Mono<Message> delayedHello() {
+		return Mono.just(new Message("Hello!"))
+				.delayElement(Duration.ofMillis(100));
+	}
 
-    public Mono<Cities> findCitiesByCountryCode(final String countryCode) {
-        return repository.findAllByCountryCode(countryCode)
-                .map(City::from)
-                .collectList()
-                .map(Cities::new);
-    }
+	public Mono<Cities> findCitiesByCountryCode(final String countryCode) {
+		return repository.findAllByCountryCode(countryCode)
+				.map(City::from)
+				.collectList()
+				.map(Cities::new);
+	}
 }


### PR DESCRIPTION
Here's a proposal for fixing the odd result you encountered with the Spring Webflux variant during your benchmark.

Using blocking calls within reactive applications is a real problem and leads to performance issues like this one. The commit message here explains a bit why.

Note that some IDEs (for example, IntelliJ IDEA) now show warning messages whenever developers try do this in their application. The Reactor team also provides tools to automatically detect such problems in your entire application (libraries included!): https://github.com/reactor/BlockHound/tree/master/docs